### PR TITLE
Room creation btn hint

### DIFF
--- a/src/components/views/Lobby.tsx
+++ b/src/components/views/Lobby.tsx
@@ -382,7 +382,7 @@ const Lobby = () => {
 
       if (Room.roomPlayersList.length === Room.roomMaxNum) {
         showToast("Room is Full, please enter another room!", "error");
-      } else if (Room.status === "In Game") {
+      } else if (Room.status !== "WAITING") {
         showToast("Game is already started, please enter another room!", "error");
       } else {
         navigate(`/rooms/${Room.roomId}`);
@@ -420,6 +420,11 @@ const Lobby = () => {
             </div>
           );
         }
+      }
+
+      // don't render the room if there is no player in the room or the game is over
+      if (Room.roomPlayersList.length === 0 || Room.status === "GAMEOVER") {
+        return ;
       }
 
       return (

--- a/src/components/views/Lobby.tsx
+++ b/src/components/views/Lobby.tsx
@@ -565,8 +565,8 @@ const Lobby = () => {
             <Button
               disabled={
                 roomName === "" ||
-                maxRoomPlayers < DEFAULT_MIN_PLAYERS ||
-                maxRoomPlayers > DEFAULT_MAX_PLAYERS ||
+                // maxRoomPlayers < DEFAULT_MIN_PLAYERS ||
+                // maxRoomPlayers > DEFAULT_MAX_PLAYERS ||
                 roomTheme === "" ||
                 isNaN(maxRoomPlayers) ||
                 specialCharactersRegex.test(roomName)


### PR DESCRIPTION
1. Remove the btn disable option, let toast hint user when he type wrong format. #171 
![image](https://github.com/sopra-fs24-group-09/sopra-fs24-group-09-client/assets/30321432/27a5d4a4-679a-4545-8982-ae7e3cf44fc1)

2. Before render room, check if it is over or empty, if so, skip this room. #170 
